### PR TITLE
Update promptify to use `parent_module_name`, not deprecated `parent_name`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    promptify (1.0.1)
+    promptify (1.0.2)
       pry
       pry-rails
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,19 @@
 PATH
   remote: .
   specs:
-    promptify (1.0.0)
+    promptify (1.0.1)
       pry
       pry-rails
 
 GEM
   remote: https://rubygems.org/
   specs:
-    coderay (1.1.2)
+    coderay (1.1.3)
     diff-lcs (1.3)
-    method_source (0.9.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     rake (10.5.0)
@@ -35,10 +35,10 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.17)
+  bundler
   promptify!
   rake (~> 10.0)
   rspec (~> 3.0)
 
 BUNDLED WITH
-   1.17.2
+   2.2.4

--- a/lib/promptify/railtie.rb
+++ b/lib/promptify/railtie.rb
@@ -15,10 +15,17 @@ module Promptify
     def show_pretty_prompt
       old_prompt = Pry.config.prompt
 
-      Pry.config.prompt = [
-        proc { |*a| "[#{app_name}]#{heroku_app}[#{environment}]> " },
-        proc { |*a| "[#{app_name}]#{heroku_app}[#{environment}]> " },
-      ]
+      if Pry::VERSION >= "0.13.0"
+        return Pry::Prompt[:promptify] if Pry::Prompt[:promptify]
+
+        Pry.prompt = Pry::Prompt.new(
+          :promptify,
+          "Simple Rails console enhancements",
+          new_prompt,
+        )
+      else
+        Pry.config.prompt = new_prompt
+      end
     end
 
     def app_name
@@ -34,6 +41,13 @@ module Promptify
       return unless ENV["HEROKU_APP_NAME"]
 
       "[#{Pry::Helpers::Text.cyan(ENV['HEROKU_APP_NAME'])}]"
+    end
+
+    def new_prompt
+      [
+        proc { |*a| "[#{app_name}]#{heroku_app}[#{environment}]> " },
+        proc { |*a| "[#{app_name}]#{heroku_app}[#{environment}]> " },
+      ]
     end
 
     def environment

--- a/lib/promptify/railtie.rb
+++ b/lib/promptify/railtie.rb
@@ -22,7 +22,12 @@ module Promptify
     end
 
     def app_name
-      Rails.application.class.parent_module_name.underscore.dasherize
+      # ActiveSupport's `Module#parent_name` is deprecated in 6.1+.
+      if Rails.application.respond_to?(:parent_module_name)
+        Rails.application.class.parent_module_name.underscore.dasherize
+      else
+        Rails.application.class.parent_name.underscore.dasherize
+      end
     end
 
     def heroku_app

--- a/lib/promptify/railtie.rb
+++ b/lib/promptify/railtie.rb
@@ -23,8 +23,8 @@ module Promptify
 
     def app_name
       # ActiveSupport's `Module#parent_name` is deprecated in 6.1+.
-      if Rails.application.respond_to?(:parent_module_name)
-        Rails.application.class.parent_module_name.underscore.dasherize
+      if Rails.application.class.respond_to?(:module_parent_name)
+        Rails.application.class.module_parent_name.underscore.dasherize
       else
         Rails.application.class.parent_name.underscore.dasherize
       end

--- a/lib/promptify/railtie.rb
+++ b/lib/promptify/railtie.rb
@@ -22,7 +22,7 @@ module Promptify
     end
 
     def app_name
-      Rails.application.class.parent_name.underscore.dasherize
+      Rails.application.class.parent_module_name.underscore.dasherize
     end
 
     def heroku_app

--- a/lib/promptify/version.rb
+++ b/lib/promptify/version.rb
@@ -1,3 +1,3 @@
 module Promptify
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/promptify.gemspec
+++ b/promptify.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "pry"
   spec.add_dependency "pry-rails"
 
-  spec.add_development_dependency "bundler", "~> 1.17"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
`parent_name` has been deprecated in `ActiveSupport`'s `Module` extension as of 6.1 -- in favor of `module_parent_name`. 

See the [6.0 deprecation message](https://github.com/rails/rails/blob/fe76a95b0d252a2d7c25e69498b720c96b243ea2/activesupport/lib/active_support/core_ext/module/introspection.rb#L20-L26):

```rb
  def parent_name
    ActiveSupport::Deprecation.warn(<<-MSG.squish)
      `Module#parent_name` has been renamed to `module_parent_name`.
      `parent_name` is deprecated and will be removed in Rails 6.1.
    MSG
    module_parent_name
  end
```

Also bumped patch version (`1.0.2`), as this shouldn't introduce any breaking changes.